### PR TITLE
Port client to Curl

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 eval "$(opam env)"
-ocamlfind opt -thread -linkpkg -package cohttp-lwt-unix app/main.ml -o app/app
+ocamlfind opt -thread -linkpkg -package curl app/main.ml -o app/app


### PR DESCRIPTION
A switch to Curl (icfpcontest2020/dockerfiles#77).

Blind implementation. Only tested that it compiles. Copied most of it from a tutorial.

This line may be needed as well (unless `Curl.set_postfieldsize` handles it):
```ocaml
Curl.set_httpheader c [ sprintf "Content-Length: %d" (String.length data) ];
```

Curl.SSLVERIFYHOST_EXISTENCE should probably be changed to SSLVERIFYHOST_NONE ("connection succeeds regardless of the names in the certificate").